### PR TITLE
Share one device package across all 16 radar cores, and fix CI discovery

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -44,6 +44,13 @@ The **authoritative radar model status table** lives in `README.md`. The AI must
 │   ├── _config.yml                    # Jekyll site config
 │   └── index.html                     # GitHub Pages install site (ESP Web Tools)
 ├── tests/
+│   ├── common/_device.yaml                    # ← Device-level entities every model gets:
+│   │                                          #   diagnostics, restart, safe mode,
+│   │                                          #   web_server, improv_serial.
+│   │                                          #   Included BY each radar core, not by
+│   │                                          #   the platform files.
+│   ├── common/_bluetooth.yaml                 # ← Opt-in BLE proxy. +502 KB flash; not
+│   │                                          #   included anywhere by default.
 │   ├── common/{radar_model}.yaml              # ← Shared radar core: uart, component,
 │   │                                          #   globals, scripts, entity wiring.
 │   │                                          #   Included by BOTH the base config here
@@ -252,6 +259,8 @@ uart:
 ```
 
 **Rules for the shared core:**
+- **Must open with `packages: device: !include _device.yaml`.** That is where WiFi Signal, Uptime, Status, IP/SSID/MAC, ESP Temperature, Restart and Safe Mode come from. A model that forgets it compiles and runs fine, and is simply missing every diagnostic — which is why this is a rule and not a suggestion.
+- Declare **no** diagnostic `sensor:`, `binary_sensor:` or `text_sensor:` block of its own. Those blocks used to be copy-pasted into every model; they now live in `_device.yaml` only. A model's own `sensor:`/`button:` entries are for radar-specific things, and merge with the package's.
 - Carries **no** `esp32:`, `wifi:`, `api:` or `external_components:` block. Each consumer supplies its own, and two declarations of the same key collide with no way to drop just one.
 - `uart.baud_rate` must match the radar's protocol document exactly. Current values range from 9600 (LD2452) to 1382400 (LD6002) — never assume 115200.
 - GPIO defaults: `GPIO20` (RX), `GPIO21` (TX). LD2410 is the sole exception at `GPIO5`/`GPIO4`. Add `# TODO` if hardware is not yet confirmed.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,13 @@ jobs:
       - uses: actions/checkout@v6
       - name: List test YAML files
         id: list
+        # -maxdepth 1 on purpose. Firmware configs live directly in tests/;
+        # tests/common/ holds packages — radar cores and the shared device
+        # package — which carry no board, no networking and no esphome: name,
+        # and cannot build on their own. Recursing into it queued one doomed
+        # job per package and is why this workflow had never been green.
         run: |
-          configs=$(find tests -name "*.yaml" | sort \
+          configs=$(find tests -maxdepth 1 -name "*.yaml" | sort \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "configs=$configs" >> "$GITHUB_OUTPUT"
           echo "Found: $configs"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,23 @@ ever sees a value:
 
 The result is a position you can write an automation against directly.
 
+### What every device exposes, whatever radar it carries
+
+Beyond the radar's own entities, each build carries the same operational
+surface — WiFi signal, uptime, online status, IP/SSID/MAC, ESP die temperature,
+a restart button and a **safe-mode restart** that boots with everything but
+WiFi and OTA disabled, for recovering a device that will not otherwise take an
+update.
+
+There is also a **local web UI** on port 80, which is the way in when Home
+Assistant is unreachable and the radar is on a ceiling, and **USB provisioning**
+(Improv) that the web flasher above drives.
+
+A **Bluetooth proxy** is available but off by default: it costs 502 KB of flash
+and shares the ESP32-C3's single radio and 320 KB of RAM with WiFi, and the
+thing that degrades is the radar's own connection to Home Assistant. Turn it on
+deliberately — see `tests/common/_bluetooth.yaml`.
+
 <img src="https://raw.githubusercontent.com/zomco/mmwave-card/main/assets/screenshot-live.gif" alt="Live View Demo" width="600">
 
 ---

--- a/tests/common/_bluetooth.yaml
+++ b/tests/common/_bluetooth.yaml
@@ -1,0 +1,53 @@
+# Optional Bluetooth stack — NOT included by default.
+#
+# A radar is mains-powered and spread through the house, which makes it an
+# attractive Bluetooth proxy. The cost is what keeps this opt-in rather than
+# part of _device.yaml:
+#
+#   Measured on an r60abd1 ESP32-C3 build, 1792 KB app partition:
+#     without this file   997 KB    54.4%
+#     with this file     1512 KB    82.4%      (+502 KB)
+#
+# Flash is only half of it. The ESP32-C3 has a single radio and 320 KB of RAM,
+# both shared between Wi-Fi and Bluetooth. Running the Bluedroid stack next to
+# Wi-Fi on this chip costs airtime and heap, and the thing it degrades is the
+# radar's own connection to Home Assistant. For a presence sensor — whose whole
+# job is reporting promptly and staying online — that is a poor trade unless
+# you actively want the proxy.
+#
+# ESP-IDF reports no static RAM figure, so the heap cost cannot be measured
+# from a build. Verify on hardware before deploying this to a device you rely
+# on, and watch for API disconnects and Wi-Fi instability rather than just
+# checking that it boots.
+#
+# Usage — add to a device config, alongside the radar package:
+#
+#   packages:
+#     radar:     !include common/<model>.yaml
+#     bluetooth: !include common/_bluetooth.yaml
+
+esp32_ble_tracker:
+  scan_parameters:
+    # Continuous scanning (interval == window) finds devices fastest but never
+    # yields the radio. These values leave Wi-Fi some room; raise the interval
+    # further if the radar starts dropping its API connection.
+    interval: 1100ms
+    window: 1100ms
+    active: true
+
+bluetooth_proxy:
+  active: true
+
+# Wi-Fi provisioning over BLE from a phone. Deliberately left off, even though
+# the BLE stack it needs is already paid for above, because the device offers
+# two provisioning paths already: improv_serial over USB (what the web
+# installer drives) and captive_portal on the fallback access point (what a
+# phone uses). A third path buys little.
+#
+# It is only cheap when this file is already included; on its own it drags in
+# the same ~400 KB BLE stack. Uncomment both keys together to enable it.
+#
+# esp32_ble_server:
+#
+# esp32_improv:
+#   authorizer: none

--- a/tests/common/_device.yaml
+++ b/tests/common/_device.yaml
@@ -1,0 +1,85 @@
+# Device-level entities shared by every radar model.
+#
+# Included by each tests/common/<model>.yaml, so a device exposes the same
+# operational surface no matter which radar it carries. Radar-specific entities
+# stay in the model file; anything here must be true of an ESP32 running any of
+# them.
+#
+# Carries no board, networking or external_components block, for the same
+# reason the radar cores do not: each consumer supplies its own, and two
+# declarations of the same key collide with no way to drop just one.
+#
+# These are all lists, which ESPHome merges across packages, so a model file
+# may still add its own sensors and buttons alongside these.
+
+sensor:
+  - platform: wifi_signal
+    name: "WiFi Signal"
+    update_interval: 60s
+    entity_category: diagnostic
+
+  - platform: uptime
+    name: "Uptime"
+    update_interval: 60s
+    entity_category: diagnostic
+
+  # On-die temperature. Not the room temperature — it reads well above ambient
+  # because it sits on the same silicon as the radio. Useful for spotting a
+  # device cooking inside a sealed ceiling enclosure, not for climate control.
+  - platform: internal_temperature
+    name: "ESP Temperature"
+    entity_category: diagnostic
+
+binary_sensor:
+  - platform: status
+    name: "Status"
+    entity_category: diagnostic
+
+text_sensor:
+  - platform: wifi_info
+    ip_address:
+      name: "IP Address"
+      entity_category: diagnostic
+    ssid:
+      name: "SSID"
+      entity_category: diagnostic
+    mac_address:
+      name: "MAC Address"
+      entity_category: diagnostic
+
+button:
+  # Named "Restart ESP" rather than "Restart" because r60abd1 already shipped
+  # under that name. Renaming would change its entity_id and silently break any
+  # dashboard or automation referring to it.
+  - platform: restart
+    name: "Restart ESP"
+    entity_category: config
+    icon: mdi:power-cycle
+
+  # Reboots with every component disabled except WiFi and OTA. This is the
+  # recovery path when a radar component wedges the device hard enough that it
+  # never reaches the point of accepting an OTA update.
+  - platform: safe_mode
+    name: "Restart (Safe Mode)"
+    entity_category: config
+    icon: mdi:lifebuoy
+
+# Local fallback UI: live entity states, logs, and a browser OTA upload. The
+# point is the case where Home Assistant is unreachable and the radar is on a
+# ceiling — without this there is no way in at all short of a ladder.
+#
+# Measured cost of web_server + improv_serial together: 24 KB, taking an
+# r60abd1 build from 53.1% to 54.4% of the 1792 KB app partition.
+#
+# NOTE: version 3 loads its JavaScript from esphome.io rather than from the
+# device. That is fine on a LAN with internet, but it means the fallback UI is
+# unavailable in exactly the wide-outage case it exists for. `local: true`
+# embeds the assets instead, at a flash cost this workspace has not yet
+# measured. Worth doing before calling the fallback story finished.
+web_server:
+  port: 80
+
+# Wi-Fi provisioning over the USB serial port, which is what the web installer
+# at static/ drives. Safe here only because the logger is on USB_SERIAL_JTAG:
+# on the ESP32-C3, UART0 is GPIO20/21, which is where every radar is wired.
+improv_serial:

--- a/tests/common/ld2410.yaml
+++ b/tests/common/ld2410.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 uart:
   id: uart_bus
   tx_pin: GPIO4

--- a/tests/common/ld2410b.yaml
+++ b/tests/common/ld2410b.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -303,34 +308,6 @@ select:
 # =============================================================================
 # 基础状态与诊断传感器
 # =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2410c.yaml
+++ b/tests/common/ld2410c.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -303,34 +308,6 @@ select:
 # =============================================================================
 # 基础状态与诊断传感器
 # =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2411.yaml
+++ b/tests/common/ld2411.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 uart:
   id: uart_ld2411
   tx_pin: GPIO21

--- a/tests/common/ld2411s.yaml
+++ b/tests/common/ld2411s.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100

--- a/tests/common/ld2412.yaml
+++ b/tests/common/ld2412.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100

--- a/tests/common/ld2420.yaml
+++ b/tests/common/ld2420.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -263,30 +268,3 @@ number:
 # 基础状态与诊断传感器
 # =============================================================================
 
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic

--- a/tests/common/ld2450.yaml
+++ b/tests/common/ld2450.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -343,34 +348,6 @@ button:
     icon: mdi:selection-search
     on_press:
       - lambda: "id(radar).query_zone_config();"
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2450a.yaml
+++ b/tests/common/ld2450a.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -323,34 +328,6 @@ button:
 # =============================================================================
 # 基础状态与诊断传感器
 # =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2451.yaml
+++ b/tests/common/ld2451.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -283,34 +288,6 @@ number:
           id(g_distance_max) = x;
           id(radar).set_distance_max(x);
           id(num_distance_max).publish_state(x);
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 button:
   - platform: template

--- a/tests/common/ld2452.yaml
+++ b/tests/common/ld2452.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -317,34 +322,6 @@ number:
           id(g_roll) = x;
           id(radar).set_roll(x);
           id(num_roll).publish_state(x);
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2453.yaml
+++ b/tests/common/ld2453.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -301,34 +306,6 @@ number:
 
 # =============================================================================
 # 鍩虹鐘舵€佷笌璇婃柇浼犳劅鍣?# =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld2454.yaml
+++ b/tests/common/ld2454.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -317,34 +322,6 @@ number:
           id(g_roll) = x;
           id(radar).set_roll(x);
           id(num_roll).publish_state(x);
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template

--- a/tests/common/ld6002.yaml
+++ b/tests/common/ld6002.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -266,30 +271,3 @@ number:
 # 基础状态与诊断传感器
 # =============================================================================
 
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic

--- a/tests/common/r60abd1.yaml
+++ b/tests/common/r60abd1.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -401,44 +406,11 @@ button:
     on_press:
       - lambda: "id(radar).reset_module();"
 
-  - platform: restart
-    name: "Restart ESP"
-    icon: mdi:power-cycle
+# 通用诊断传感器（WiFi Signal / Uptime / Status / IP / SSID / MAC）和重启按钮
+# 已移入 _device.yaml，由本文件顶部的 packages 引入。
 
 # =============================================================================
-# 9. 诊断传感器
-# =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
-
-# =============================================================================
-# 10. Text 实体（接收 Lovelace 卡片下发的多边形字符串）
+# 9. Text 实体（接收 Lovelace 卡片下发的多边形字符串）
 # =============================================================================
 
 text:

--- a/tests/common/rd03e.yaml
+++ b/tests/common/rd03e.yaml
@@ -8,6 +8,11 @@
 # each consumer supplies its own, and two declarations of the same key
 # would collide with no way to drop just one.
 
+# Diagnostics and recovery controls are the same on every model, so they live
+# in one place rather than being copied into sixteen radar cores.
+packages:
+  device: !include _device.yaml
+
 esphome:
   on_boot:
     priority: -100
@@ -280,34 +285,6 @@ button:
 # =============================================================================
 # 基础状态与诊断传感器
 # =============================================================================
-
-sensor:
-  - platform: wifi_signal
-    name: "WiFi Signal"
-    update_interval: 60s
-    entity_category: diagnostic
-
-  - platform: uptime
-    name: "Uptime"
-    entity_category: diagnostic
-    update_interval: 60s
-
-binary_sensor:
-  - platform: status
-    name: "Status"
-    entity_category: diagnostic
-
-text_sensor:
-  - platform: wifi_info
-    ip_address:
-      name: "IP Address"
-      entity_category: diagnostic
-    ssid:
-      name: "SSID"
-      entity_category: diagnostic
-    mac_address:
-      name: "MAC Address"
-      entity_category: diagnostic
 
 text:
   - platform: template


### PR DESCRIPTION
## The problem

Every model needs the same operational entities, and until now they were copy-pasted. Surveying the sixteen radar cores:

| | Coverage |
| --- | --- |
| `wifi_signal` / `uptime` / `status` / `wifi_info` | 12 of 16 — **byte-identical duplicates**. Missing entirely from `ld2410`, `ld2411`, `ld2411s`, `ld2412` |
| restart button | 1 of 16 (`r60abd1` only) |
| die temperature | 0 of 16 |
| safe-mode restart | 0 of 16 |

Four models therefore had no way to report their own health at all.

## The change

`tests/common/_device.yaml` holds that surface once; each radar core includes it. **342 lines removed** across the sixteen, and the four laggards gain what they were missing.

Two entities are new everywhere:

- **ESP Temperature** — on-die, not room temperature. It is how you spot a device cooking inside a sealed ceiling enclosure. The two devices measured while testing this differ by nearly 20 °C, so it is already earning its place.
- **Restart (Safe Mode)** — reboots with everything but WiFi and OTA disabled. The recovery path when a radar component wedges the device hard enough that it never reaches the point of accepting an update. Previously: a ladder and a USB cable.

The restart button keeps the name **"Restart ESP"** that `r60abd1` already shipped, so its entity_id does not change and nothing referring to it breaks.

Also added for every model:

- **`web_server`** on port 80 — a local fallback UI for when Home Assistant is unreachable and the radar is on a ceiling.
- **`improv_serial`** — WiFi provisioning over USB, which is what the web installer in `static/` drives. Safe only because the logger sits on `USB_SERIAL_JTAG`; on the ESP32-C3, UART0 is GPIO20/21, which is where every radar is wired.

## Flash budget

Measured on an `r60abd1` build against the 1792 KB app partition:

| Configuration | Flash | Partition |
| --- | ---: | ---: |
| before | 971,728 B | 53.0% |
| + diagnostics, safe mode, die temp | 973,488 B | 53.1% |
| + `web_server`, `improv_serial` | 997,984 B | 54.4% |
| *(+ Bluetooth, for reference)* | *1,512,448 B* | *82.4%* |

## Why Bluetooth is opt-in

`tests/common/_bluetooth.yaml` is added but **included nowhere**. A mains-powered radar spread through the house is an attractive Bluetooth proxy, but the stack costs **502 KB** and shares the C3's single radio and 320 KB of RAM with WiFi. What that degrades is the radar's own link to Home Assistant — a poor trade for a presence sensor unless the proxy is actually wanted.

ESP-IDF reports no static RAM figure, so the heap cost cannot be measured from a build; the file says so and says to verify on hardware before relying on it.

`esp32_improv` is left commented out inside that file for a related reason: the BLE stack it needs would already be paid for there, but the device provisions over USB (`improv_serial`) and over `captive_portal` already, so a third path buys little. **This narrows what was originally scoped** — flagging it explicitly.

## Verification

- `esphome config` — **28/28** firmware configs pass, plus 14/14 in the consuming workspace
- Every one of the sixteen models resolves **exactly one** of each diagnostic entity — no duplicates, none dropped
- The block removals were applied only where the text matched the canonical version byte-for-byte, so a model that had quietly added a sensor of its own would have been skipped and reported rather than silently trimmed

Flashed over OTA to two bench devices covering **both shapes** of the change:

| | `r60abd1` (lost its own block) | `ld2412` (had none before) |
| --- | --- | --- |
| Firmware | 997,968 B | 979,040 B |
| New entities | present, `esp_temperature` 45 °C | all 7 present, `esp_temperature` 58 °C |
| entity_id stability | `restart_esp` unchanged | — |
| Radar function | breath 22, HR 81, room coords, atomic frame | presence, 14 gate energies, room coords |
| Calibration globals | survived OTA (`radar_x=60, z=150, yaw=45`) | — |
| `Mock Data` (e2e determinism) | intact | intact |
| Entity duplicates | none in 40 | none in 49 |
| Stability | up 13 min, no reboot | up, no reboot |

**Not verified:** `improv_serial` and the serial-logging path both need a USB cable; the bench work here was entirely over OTA.

## Note for reviewers

The AI guide (`.github/copilot-instructions.md`) is updated to match. A model that forgets the device package compiles and runs fine and is simply missing every diagnostic, so it is written there as a rule rather than a suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
