### PR TITLE
Stop the rd03e presence watchdog firing during mock injection

### DIFF
--- a/components/rd03e/rd03e.cpp
+++ b/components/rd03e/rd03e.cpp
@@ -19,10 +19,18 @@ void RD03EComponent::loop() {
   const uint32_t now = millis();
   while (available()) {
     const uint8_t byte = read();
+    // Stamp the receive time before deciding whether to use the byte. Bytes are
+    // still arriving while mock data is active — they are discarded, not
+    // absent — and the watchdog below reads this to decide whether the radar
+    // has gone quiet. Stamping it after the skip meant that one second into any
+    // injection the watchdog concluded the link was dead and published
+    // presence = false, wiping the state the injection had just set. Every
+    // other component with mock support either does it in this order or leaves
+    // loop() entirely while mock is active.
+    last_rx_ms_ = now;
     if (now < this->mock_active_until_) {
       continue;
     }
-    last_rx_ms_ = now;
     process_byte_(byte);
   }
 


### PR DESCRIPTION
`loop()` stamped `last_rx_ms_` only after deciding the byte was wanted:

```cpp
while (available()) {
  const uint8_t byte = read();
  if (now < this->mock_active_until_) { continue; }   // ← skips the stamp
  last_rx_ms_ = now;
  process_byte_(byte);
}

// Presence watchdog
if (now - this->last_rx_ms_ > 1000) { presence -> false; }
```

Bytes keep arriving while mock data is active — they are **discarded, not absent** — so the stamp went stale. One second into any injection the watchdog concluded the radar had gone quiet and published `presence = false`, wiping the state the injection had just set.

Moving the stamp above the skip fixes it. The watchdog is about the UART being alive, which it is; mock mode is about which bytes get *parsed*.

## rd03e was the only one

Of the twelve components that support mock injection, the rest already handle this, by one of two patterns:

| Pattern | Components |
| --- | --- |
| Leaves `loop()` entirely while mock is active | ld2410, ld2410b, ld2410c, ld2412, ld2453 |
| Refreshes the timestamp before skipping | ld2450, ld2450a, ld2451, ld2452, ld2454, r60abd1 |

rd03e used neither. It now matches the second group.

## Why it was worth chasing

Production is unaffected — mock mode is never active there. But it made two end-to-end presence tests unpassable, and the obvious reading of those failures was that injection did not work at all.

It did. Dumping state at the moment of the assertion showed the injected values landing correctly and then being overwritten:

```
after inject  presence=on  distance=74.0   motion_state=2.0   (live, injection not yet applied)
+1.5s         presence=off distance=150.0  motion_state=1.0   (injected values — presence wiped)
```

`distance` and `motion_state` are exactly what was injected. Only `presence` was clobbered, by the watchdog.

## Verification

Flashed to the bench device over OTA. rd03e's e2e suite goes from 2 failures to none, and the full suite across six models is **38 passed, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
