### PR TITLE
Make the ld2412 mock entity match every other model

### DIFF
--- a/tests/common/ld2412.yaml
+++ b/tests/common/ld2412.yaml
@@ -182,10 +182,18 @@ ld2412:
 
 text:
   - platform: template
-    name: "ld2412_test_device Mock Data"
+    # "Mock Data", not "ld2412_test_device Mock Data". Home Assistant already
+    # prefixes the device name, so the longer form produced
+    # text.ld2412_test_device_ld2412_test_device_mock_data — the only model
+    # spelled differently from the other eleven, and a name nothing could
+    # reasonably guess.
+    name: "Mock Data"
     id: text_ld2412_mock_data
     mode: text
     optimistic: true
-    on_value:
+    # set_action, not on_value. on_value fires only when the value *changes*,
+    # so replaying the same frame twice — which is how the e2e harness gets past
+    # the 1 Hz publish rate limit — silently did nothing the second time.
+    set_action:
       - lambda: |-
           id(radar).inject_mock_data(x.c_str());


### PR DESCRIPTION
Two things made this device untestable, and both were unique to it among the twelve models that support mock injection.

## The entity had an unguessable id

```yaml
name: "ld2412_test_device Mock Data"
```

Home Assistant prefixes the device name itself, so that produced:

```
text.ld2412_test_device_ld2412_test_device_mock_data
```

A test written against the obvious id wrote to an entity that does not exist — silently, because `text.set_value` on an unknown entity reports nothing back. The injection simply never happened, and the specs then asserted against live radar data.

Every other model calls it `"Mock Data"`.

## The trigger was `on_value`

`on_value` fires only when the value *changes*. The e2e harness deliberately sends each frame **twice, 1.2 s apart**, to get past the component's 1 Hz publish rate limit — with `on_value` the second send did nothing.

Every other model uses `set_action`.

## Verification

Flashed to the bench device over OTA. The entity is now `text.ld2412_test_device_mock_data` and injected frames land; ld2412's new e2e suite passes 4/4.

Found while adding that suite — ld2412 was one of three models that had a device, OTA and mock support but no coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
