### PR TITLE
chore: group Dependabot's updates, and watch the installer front-end

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,53 @@
+# Dependency updates.
+#
+# This was deliberately left until last, because the failure mode of Dependabot
+# is not missing an update — it is fifteen pull requests nobody reads, after
+# which the ones that matter are invisible too. Everything here is shaped to
+# avoid that:
+#
+#   * Minor and patch bumps are grouped into one pull request per ecosystem.
+#     They are the ones that are almost always safe and almost never
+#     individually interesting.
+#   * Majors are left ungrouped on purpose, so each arrives alone and gets
+#     read. A major of lit or of an ESPHome action is a change, not a bump.
+#   * The open-PR limit is low. If the queue is full, that is a signal to go
+#     and merge something rather than to raise the limit.
 version: 2
 updates:
+  # Actions are the highest-value, lowest-noise ecosystem here: they release a
+  # few times a year, and a stale one is how a workflow quietly stops working.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+
+  # The web installer front-end. It was outside the previous config entirely,
+  # so its dependencies had never been looked at by anything.
+  - package-ecosystem: "npm"
+    directory: "/static"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+    open-pull-requests-limit: 3
+    groups:
+      npm-development:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      npm-production:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Two changes to a config that was already working.

**The web installer under `static/` was outside it entirely**, so its eight npm dependencies had never been looked at by anything. It is the front-end people flash their devices from; it should not be the one part of this repository nothing watches.

**The updates are now grouped.** Ungrouped, this repository accumulated open Dependabot pull requests one action at a time — which is the failure mode worth designing against, because once there are several, nobody reads any of them. Minor and patch bumps now arrive together; majors are deliberately left ungrouped so each arrives alone and gets read.

The two currently-open major bumps (`actions/checkout` 6→7, `actions/setup-node` 6→7) are left for a separate decision rather than swept in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)