### PR TITLE
chore: bump the clang-format job to checkout v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     name: clang-format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # Pinned rather than floating: a new clang-format release changes its mind
       # about some wrapping every so often, and a formatting job that fails


### PR DESCRIPTION
Dependabot's bump landed on the five `actions/checkout` uses that existed when it opened the pull request. The `clang-format` job was added after that, so it kept `v6` and was the only thing in the repository still on it.

v7's breaking change — refusing to check out a fork's pull request head under `pull_request_target` or `workflow_run` — does not apply to this job, which runs on `pull_request` and checks out the repository itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)